### PR TITLE
cut heap allocation by 23%

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -674,7 +674,7 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LorentzVectorHEP]]
 deps = ["LorentzVectors"]
-git-tree-sha1 = "ea3deabb96e9019994811bdecc85190126b6cb83"
+git-tree-sha1 = "f174d2e809ab20e2e5a902d9899d0b0d73258edc"
 uuid = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 version = "0.1.3"
 


### PR DESCRIPTION
Running over 10 `ttbar` files:

Before:
```julia
julia> @benchmark LHC_AGC.get_histo(:ttbar, 10)
BenchmarkTools.Trial: 4 samples with 1 evaluation.
 Range (min … max):  1.377 s …  1.388 s  ┊ GC (min … max): 11.42% … 11.70%
 Time  (median):     1.383 s             ┊ GC (median):    11.56%
 Time  (mean ± σ):   1.383 s ± 4.461 ms  ┊ GC (mean ± σ):  11.34% ±  0.63%

  █                       █        █                     █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.38 s        Histogram: frequency by time        1.39 s <

 Memory estimate: 1.62 GiB, allocs estimate: 13198686.
```

After:
```julia
julia> @benchmark LHC_AGC.get_histo(:ttbar, 10)
BenchmarkTools.Trial: 5 samples with 1 evaluation.
 Range (min … max):  1.202 s …  1.221 s  ┊ GC (min … max): 10.10% … 11.32%
 Time  (median):     1.206 s             ┊ GC (median):    10.62%
 Time  (mean ± σ):   1.210 s ± 7.608 ms  ┊ GC (mean ± σ):  10.62% ±  0.45%

  ▁          █                      ▁                    ▁  
  █▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.2 s         Histogram: frequency by time        1.22 s <

 Memory estimate: 1.25 GiB, allocs estimate: 7173242.
```